### PR TITLE
Fix for Issue #18. Added binary mode to write() to fix corrupt file output.

### DIFF
--- a/mm/document_writers.py
+++ b/mm/document_writers.py
@@ -32,7 +32,7 @@ class DocumentWriter(object):
             self.composer = ComposerPrettyTable(self.data_model, self.grid, self)
             log.info("Setting output format to TXT, based on file extension")
 
-        f = open(filename, "w")
+        f = open(filename, "wb")
         f.write(self.writestr())
         f.close()
         log.info("wrote file: %s" % filename)


### PR DESCRIPTION
This pull request is to fix issue #18

The problem was that `write()` was not writing in binary mode thereby corrupting the output XLS file. 

I fixed this issue by adding binary mode 'b' to the `open()` arguments.
