### PR TITLE
Fix Issues #24 and #25

### DIFF
--- a/mm/document_writers.py
+++ b/mm/document_writers.py
@@ -32,9 +32,9 @@ class DocumentWriter(object):
             self.composer = ComposerPrettyTable(self.data_model, self.grid, self)
             log.info("Setting output format to TXT, based on file extension")
 
-        f = open(filename, "wb")
-        f.write(self.writestr())
-        f.close()
+        with open(filename, "wb") as f:
+            f.write(self.writestr())
+        
         log.info("wrote file: %s" % filename)
 
     def write_gdata(self, name, username, password, auth_token=None):

--- a/scripts/textwidths.py
+++ b/scripts/textwidths.py
@@ -118,9 +118,9 @@ for font  in font_list:
 
 # write in binary pickle mode
 import cPickle as pickle
-f = open("font_data.bin","wb")
-pickle.dump(fonts,f,True)
-f.close()
+with open("font_data.bin","wb") as f:
+    pickle.dump(fonts,f,True)
+
 
 
 

--- a/tests/basic_tests.py
+++ b/tests/basic_tests.py
@@ -31,10 +31,9 @@ class TestBasicSuite(unittest.TestCase):
         self.assertTrue(
             len(str) > 10,
             msg="String should be longer than %s" % len(str))
-        f = open("test_doc.xls", "wb")
-        f.write(str)
-        f.close()
-        self.check("test_doc.xls", my_data)
+        with open("tests/generated_files/test_doc.xls", "wb") as f:
+            f.write(str)
+        self.check("tests/generated_files/test_doc.xls", my_data)
 
     def test_minimal_lists(self):
 
@@ -49,11 +48,11 @@ class TestBasicSuite(unittest.TestCase):
         self.assertTrue(
             len(str) > 10,
             msg="String should be longer than %s" % len(str))
-        f = open("test_list_doc.xls", "wb")
-        f.write(str)
-        f.close()
+        with open("tests/generated_files/test_list_doc.xls", "wb") as f:
+            f.write(str)
+        
         as_dict = [dict(zip(my_headers, row)) for row in my_data]
-        self.check("test_list_doc.xls", as_dict)
+        self.check("tests/generated_files/test_list_doc.xls", as_dict)
 
     def check(self, filename, my_data):
         xls = XLSReader(filename)
@@ -99,11 +98,10 @@ class TestBasicSuite(unittest.TestCase):
         self.assertTrue(
             len(str) > 10,
             msg="String should be longer than %s" % len(str))
-        f = open("test_doc2.xls", "wb")
-        f.write(str)
-        f.close()
+        with open("tests/generated_files/test_doc2.xls", "wb") as f:
+            f.write(str)
 
-        #TODO self.check("test_doc2.xls", my_data)
+        #TODO self.check("tests/generated_files/test_doc2.xls", my_data)
 
     def test_image(self):
 
@@ -117,8 +115,8 @@ class TestBasicSuite(unittest.TestCase):
         self.assertTrue(
             len(str) > 10,
             msg="String should be longer than %s" % len(str))
-        f = open("test_doc_image.xls", "wb")
-        f.write(str)
+        with open("tests/generated_files/test_doc_image.xls", "wb") as f:
+            f.write(str)
 
     def test_col_type(self):
 
@@ -133,8 +131,8 @@ class TestBasicSuite(unittest.TestCase):
         self.assertTrue(
             len(str) > 10,
             msg="String should be longer than %s" % len(str))
-        f = open("test_col_types.xls", "wb")
-        f.write(str)
+        with open("tests/generated_files/test_col_types.xls", "wb") as f:
+            f.write(str)
 
     def test_missing_1(self):
         my_data = [
@@ -154,10 +152,9 @@ class TestBasicSuite(unittest.TestCase):
         self.assertTrue(
             len(str) > 10,
             msg="String should be longer than %s" % len(str))
-        f = open("test_doc.xls", "wb")
-        f.write(str)
-        f.close()
-        self.check("test_doc.xls", my_data)
+        with open("tests/generated_files/test_doc.xls", "wb") as f:
+            f.write(str)
+        self.check("tests/generated_files/test_doc.xls", my_data)
 
     def test_missing_2(self):
         my_data = [
@@ -181,10 +178,9 @@ class TestBasicSuite(unittest.TestCase):
             self.assertTrue(
                 len(str) > 10,
                 msg="String should be longer than %s" % len(str))
-            f = open("test_doc.xls", "wb")
-            f.write(str)
-            f.close()
-            self.check("test_doc.xls", my_data)
+            with open("test_doc.xls", "wb") as f:
+                f.write(str)
+            self.check("tests/generated_files/test_doc.xls", my_data)
     
     def test_write_and_writestr_binary_output(self):
         """
@@ -205,14 +201,15 @@ class TestBasicSuite(unittest.TestCase):
         
         # Write using write()
         mm_doc = mm.Document(my_data)
-        mm_doc.write('test_file1.xls')
+        mm_doc.write("tests/generated_files/test_file1.xls")
 
         # Write using writestr() in binary mode
         str = mm_doc.writestr()
-        with open('test_file2.xls', 'wb') as f:
+        with open("tests/generated_files/test_file2.xls", "wb") as f:
             f.write(str)
 
-        self.assertTrue(filecmp.cmp('test_file1.xls', 'test_file2.xls'))
+        self.assertTrue(filecmp.cmp("tests/generated_files/test_file1.xls", 
+                                    "tests/generated_files/test_file2.xls"))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/customize_tests.py
+++ b/tests/customize_tests.py
@@ -33,9 +33,9 @@ class CustomTestSuite(unittest.TestCase):
         str = mm_doc.writestr()
         self.assertTrue(len(str) > 10, 
             msg="String should be longer than %s" % len(str))
-        f = open("test_custom_no_header.xls", "wb")
-        f.write(str)
-        f.close()
+        with open("tests/generated_files/test_custom_no_header.xls", "wb") as f:
+            f.write(str)
+        
 
 
     def test_no_style(self):
@@ -49,9 +49,9 @@ class CustomTestSuite(unittest.TestCase):
         str = mm_doc.writestr()
         self.assertTrue(len(str) > 10, 
             msg="String should be longer than %s" % len(str))
-        f = open("test_custom_no_styles.xls", "wb")
-        f.write(str)
-        f.close()
+        with open("tests/generated_files/test_custom_no_styles.xls", "wb") as f:
+            f.write(str)
+        
 
 
     def test_row_style(self):
@@ -64,9 +64,9 @@ class CustomTestSuite(unittest.TestCase):
         str = mm_doc.writestr()
         self.assertTrue(len(str) > 10, 
             msg="String should be longer than %s" % len(str))
-        f = open("test_custom_row_styles.xls", "wb")
-        f.write(str)
-        f.close()
+        with open("tests/generated_files/test_custom_row_styles.xls", "wb") as f:
+            f.write(str)
+        
 
         
 if __name__ == "__main__":

--- a/tests/django_tests.py
+++ b/tests/django_tests.py
@@ -34,9 +34,9 @@ class DjangoTestSuite(unittest.TestCase):
         str = mm_doc.writestr()
         self.assertTrue(len(str) > 10,
             msg="String should be longer than %s" % len(str))
-        f = open("test_django_serializer.xls", "wb")
-        f.write(str)
-        f.close()
+        with open("tests/generated_files/test_django_serializer.xls", "wb") as f:
+            f.write(str)
+        
 
 
 

--- a/tests/dup_type_fix_tests.py
+++ b/tests/dup_type_fix_tests.py
@@ -25,9 +25,9 @@ class TestBasicSuite(unittest.TestCase):
         str = mm_doc.writestr()
         self.assertTrue(len(str) > 10, 
             msg="String should be longer than %s" % len(str))
-        f = open("test_dup.xls", "wb")
-        f.write(str)
-        f.close()
+        with open("tests/generated_files/test_dup.xls", "wb") as f:
+            f.write(str)
+    
         self.check("test_dup.xls", my_data)
 
     def check(self, filename, my_data):

--- a/tests/dup_type_fix_tests.py
+++ b/tests/dup_type_fix_tests.py
@@ -28,7 +28,7 @@ class TestBasicSuite(unittest.TestCase):
         with open("tests/generated_files/test_dup.xls", "wb") as f:
             f.write(str)
     
-        self.check("test_dup.xls", my_data)
+        self.check("tests/generated_files/test_dup.xls", my_data)
 
     def check(self, filename, my_data):
         xls = XLSReader(filename)

--- a/tests/generated_files/.gitignore
+++ b/tests/generated_files/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/tests/more_data_tests.py
+++ b/tests/more_data_tests.py
@@ -28,10 +28,10 @@ class TestMoreDataSuite(unittest.TestCase):
         self.assertTrue(
             len(str) > 10,
             msg="String should be longer than %s" % len(str))
-        f = open("test_multi_data.xls", "wb")
-        f.write(str)
-        f.close()
-        self.check("test_multi_data.xls", my_data)
+        with open("tests/generated_files/test_multi_data.xls", "wb") as f:
+            f.write(str)
+        
+        self.check("tests/generated_files/test_multi_data.xls", my_data)
 
     def check(self, filename, my_data):
         xls = XLSReader(filename)

--- a/tests/multi_sheets.py
+++ b/tests/multi_sheets.py
@@ -34,10 +34,10 @@ class TestMultiSuite(unittest.TestCase):
         self.assertTrue(
             len(str) > 10,
             msg="String should be longer than %s" % len(str))
-        f = open("test_multi.xls", "wb")
-        f.write(str)
-        f.close()
-        self.check("test_multi.xls", my_data)
+        with open("tests/generated_files/test_multi.xls", "wb") as f:
+            f.write(str)
+        
+        self.check("tests/generated_files/test_multi.xls", my_data)
 
     def check(self, filename, my_data):
         xls = XLSReader(filename)

--- a/tests/psycopg2_tests.py
+++ b/tests/psycopg2_tests.py
@@ -50,10 +50,10 @@ class PsycopgTestSuite(unittest.TestCase):
         self.assertTrue(
             len(str) > 10,
             msg="String should be longer than %s" % len(str))
-        f = open("test_psycopg.xls", "wb")
-        f.write(str)
-        f.close()
-        self.check("test_psycopg.xls", my_data)
+        with open("tests/generated_files/test_psycopg.xls", "wb") as f:
+            f.write(str)
+        
+        self.check("tests/generated_files/test_psycopg.xls", my_data)
 
     def check(self, filename, my_data):
         xls = XLSReader(filename)


### PR DESCRIPTION
This is my pull request to fix issue #24 and #25.

Issue #24 was about changing the syntax `f = open(..)` to `with open(..) as f`

Issue #25 was about generating the `*.xls` files into their own subdirectory `tests/generated_files`

A bunch of `*_tests.py` have been affected but the non-test files that have been affected are:

```
document_writers.py
textwidths.py
```

All tests have passed as a result of these changes.
